### PR TITLE
Display parent groups only in the Topics page

### DIFF
--- a/ckanext/grouphierarchy/helpers.py
+++ b/ckanext/grouphierarchy/helpers.py
@@ -28,7 +28,7 @@ def get_parent_groups():
 
     for group in groups:
         if group['name'] in group_list:
-            parent_groups.append(group['name'])
+            parent_groups.append(group)
 
     return parent_groups
 

--- a/ckanext/grouphierarchy/templates/group/index.html
+++ b/ckanext/grouphierarchy/templates/group/index.html
@@ -25,9 +25,8 @@
 
       {% block groups_list %}
         {% if c.page.items or request.params %}
-          {% if c.page.items %}
-            {% snippet "group/snippets/group_list.html", groups=c.page.items %}
-          {% endif %}
+            {% set featured = h.get_parent_groups() %}
+            {% snippet "group/snippets/group_list.html", groups=featured %}
         {% else %}
           <p class="empty">
             {{ _('There are currently no topics for this site') }}.

--- a/ckanext/grouphierarchy/templates/group/snippets/group_list.html
+++ b/ckanext/grouphierarchy/templates/group/snippets/group_list.html
@@ -11,11 +11,8 @@ Example:
 {% block group_list %}
 <ul class="media-grid" data-module="media-grid">
   {% block group_list_inner %}
-  {% set featured = h.get_parent_groups() %}
   {% for group in groups %}
-  	{% if group.name in featured %}
-    	{% snippet "group/snippets/group_item.html", group=group, position=loop.index %}
-    {% endif %}
+        {% snippet "group/snippets/group_item.html", group=group, position=loop.index %}
   {% endfor %}
   {% endblock %}
 </ul>


### PR DESCRIPTION
The issue was that in the dataset topics page we were seeing only the featured groups instead of all groups associated with the datasets.

This PR attempts to fix that by applying the featured_groups filter only to the topics index page. 

Partially addresses https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/27.