### PR TITLE
Fix images in child group list

### DIFF
--- a/ckanext/grouphierarchy/helpers.py
+++ b/ckanext/grouphierarchy/helpers.py
@@ -1,5 +1,6 @@
 import ckan.plugins as p
 import ckan.model as model
+import ckan.logic as logic
 from ckan.common import request, config
 import ckan.lib.helpers as h
 
@@ -74,6 +75,9 @@ def get_group_collection_count(group):
 
     return len(collections)
 
+def get_group_show(group_id):
+    group_details = logic.get_action('group_show')({}, {'id': group_id })
+    return group_details
 
 def collection_information(collection_id=None):
     collections = opensearch_config.load_settings("collections_list")

--- a/ckanext/grouphierarchy/plugin.py
+++ b/ckanext/grouphierarchy/plugin.py
@@ -29,6 +29,7 @@ class GrouphierarchyPlugin(plugins.SingletonPlugin, DefaultGroupForm):
                 'get_topic_type_internal': helpers.get_topic_type_internal,
                 'get_topic_type_external': helpers.get_topic_type_external,
                 'get_parent_collections': helpers.get_parent_collections,
+                'get_group_show': helpers.get_group_show,
                 }
 
     # IGroupForm

--- a/ckanext/grouphierarchy/templates/group/snippets/children_group_list.html
+++ b/ckanext/grouphierarchy/templates/group/snippets/children_group_list.html
@@ -21,7 +21,8 @@ Example:
 				<div class="topic-list">
 					<ul class="media-grid masonry" style="position: relative">
 						{% for group in internal_topics %}
-							{% snippet "group/snippets/children_group_item.html", group=group, position=loop.index %}
+							{% set group_dict = h.get_group_show(group.id) %}
+							{% snippet "group/snippets/children_group_item.html", group=group_dict, position=loop.index %}
 						{% endfor %}
 					</ul>
 				</div>
@@ -37,7 +38,8 @@ Example:
 				<div class="topic-list">
 					<ul class="media-grid masonry" style="position: relative">
 						{% for group in external_topics %}
-							{% snippet "group/snippets/children_group_item.html", group=group, position=loop.index %}
+							{% set group_dict = h.get_group_show(group.id) %}
+							{% snippet "group/snippets/children_group_item.html", group=group_dict, position=loop.index %}
 						{% endfor %}
 					</ul>
 				</div>


### PR DESCRIPTION
Fixes https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/101

Images were not available for internal and external services because the group object returned by "model.Group.get" do not include the `image_display_url` attribute.
This PR attempts to solve that by retrieving the group details via `group_show` before attempting to display them.