### PR TITLE
Display only child dataset groups

### DIFF
--- a/ckanext/grouphierarchy/helpers.py
+++ b/ckanext/grouphierarchy/helpers.py
@@ -35,7 +35,7 @@ def get_parent_groups():
 
 def get_children_groups():
     group_list = model.Group.all(group_type='group')
-    parent_group_names = get_parent_groups()
+    parent_group_names = [group['name'] for group in get_parent_groups()]
     children_groups = [group for group in group_list
                        if group.name not in parent_group_names]
 

--- a/ckanext/grouphierarchy/plugin.py
+++ b/ckanext/grouphierarchy/plugin.py
@@ -27,6 +27,7 @@ class GrouphierarchyPlugin(plugins.SingletonPlugin, DefaultGroupForm):
                 'get_children_names': helpers.get_children_names,
                 'get_children_group_count': helpers.get_children_group_count,
                 'get_parent_groups': helpers.get_parent_groups,
+                'get_children_groups': helpers.get_children_groups,
                 'get_topic_type_internal': helpers.get_topic_type_internal,
                 'get_topic_type_external': helpers.get_topic_type_external,
                 'get_topic_collections': helpers.get_topic_collections,

--- a/ckanext/grouphierarchy/templates/package/group_list.html
+++ b/ckanext/grouphierarchy/templates/package/group_list.html
@@ -33,9 +33,11 @@
             {% block group_list %}
             <ul class="media-grid" data-module="media-grid">
                 {% block group_list_inner %}
-                {% set featured = h.get_parent_groups() %}
+                {% set childrenGroupNames = h.get_children_groups() | map(attribute='name') %}
                 {% for group in c.pkg_dict.groups %}
+                  {% if group.name in childrenGroupNames %}
                     {% snippet "group/snippets/group_item.html", group=group, position=loop.index %}
+                  {% endif %}
                 {% endfor %}
                 {% endblock %}
             </ul>


### PR DESCRIPTION
Some changes in https://github.com/NextGeoss/ckanext-grouphierarchy/pull/8 were broken by changes in https://github.com/NextGeoss/ckanext-grouphierarchy/commit/2b61e6d49dbd8dcbdb38d8991d93f3758c80ad82 because the method `get_children_groups` was relying on the method `get_parent_groups` which was changed.

All the changes were for the better thought because now both methods return `group` objects not just names so in this PR I just make sure that only child groups are can be assigned and displayed for datasets. 