### PR TITLE
Fix design issues on parent topic page

### DIFF
--- a/ckanext/grouphierarchy/templates/group/read.html
+++ b/ckanext/grouphierarchy/templates/group/read.html
@@ -6,8 +6,6 @@
 
 
 {% block primary_content_inner %}
-  <h3 class="topic-collections-title"><i class="fa fa-info-circle"></i> Data Collections used by Pilot: </h3>
-
   {% block packages_list %}
     {% set collections = h.get_topic_collections(group.name) %}
     {% if collections|length > 0 %}

--- a/ckanext/grouphierarchy/templates/group/snippets/group_parent.html
+++ b/ckanext/grouphierarchy/templates/group/snippets/group_parent.html
@@ -47,7 +47,7 @@
         {% endblock %}
       {%- else -%}
         <section id="dataset-resources" class="resources">
-          <hr style="border-top: 1px solid black">
+          <h3><i class="fa fa-hashtag"></i><b> {{ _('NextGEOSS Pilots') }}</b></h3>
           <h4>Pilot applications are coming soon</h4>
         </section>
       {% endif %}


### PR DESCRIPTION
Fixes https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/187

When the topic doesn't have any pilots it now looks like this:

![image](https://user-images.githubusercontent.com/8862002/67401701-cf72cd00-f5af-11e9-954a-04007686e837.png)

It has at least one external or internal pilot, the corresponding section is displayed:

![image](https://user-images.githubusercontent.com/8862002/67401821-fa5d2100-f5af-11e9-9331-128cf9519d60.png)
