### PR TITLE
Fix output datasets

### DIFF
--- a/ckanext/grouphierarchy/helpers.py
+++ b/ckanext/grouphierarchy/helpers.py
@@ -134,9 +134,10 @@ def get_output_datasets(group):
     group_packages = group.packages()
     for package in group_packages:
         package_details = logic.get_action('package_show')({}, {'id': package.id })
-        for d in package_details['extras']:
-            if d['key'] == 'is_output' and bool(d['value']) == True:
-                output_datasets.append(package_details)
+        is_output = [obj for obj in package_details.get('extras') if obj['key'] == 'is_output'][0]
+        if bool(is_output.get('value')) == True:
+            output_datasets.append(package_details)
+
     return output_datasets
 
 

--- a/ckanext/grouphierarchy/helpers.py
+++ b/ckanext/grouphierarchy/helpers.py
@@ -134,9 +134,10 @@ def get_output_datasets(group):
     group_packages = group.packages()
     for package in group_packages:
         package_details = logic.get_action('package_show')({}, {'id': package.id })
-        is_output = [obj for obj in package_details.get('extras') if obj['key'] == 'is_output'][0]
-        if bool(is_output.get('value')) == True:
-            output_datasets.append(package_details)
+        is_output = [obj for obj in package_details.get('extras') if obj['key'] == 'is_output']
+        if len(is_output) > 0:
+            if bool(is_output[0].get('value')) == True:
+                output_datasets.append(package_details)
 
     return output_datasets
 

--- a/ckanext/grouphierarchy/helpers.py
+++ b/ckanext/grouphierarchy/helpers.py
@@ -133,11 +133,10 @@ def get_output_datasets(group):
     group = model.Group.get(group['name'])
     group_packages = group.packages()
     for package in group_packages:
-        extras = package.as_dict().get('extras', {})
-        if extras.get('is_output') == 'true':
-            package_details = logic.get_action('package_show')({}, {'id': package.id })
-            output_datasets.append(package_details)
-
+        package_details = logic.get_action('package_show')({}, {'id': package.id })
+        for d in package_details['extras']:
+            if d['key'] == 'is_output' and bool(d['value']) == True:
+                output_datasets.append(package_details)
     return output_datasets
 
 


### PR DESCRIPTION
Due to inconsistencies in the format of our extras some output datasets were not passing the checks. 

This PR attempts to solve that by fetching the datasets through `package_show` and converting the value of `is_output` to a bool. 

Fixes  https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/188

Using `package_show`makes the request quite slow as explained in https://github.com/NextGeoss/nextgeoss-catalogue-issues/issues/203 so in terms of speed there is definitely room for improvement as I explained there.