### PR TITLE
Manage button for topics

### DIFF
--- a/ckanext/grouphierarchy/templates/group/read_page_primary_hierarchy.html
+++ b/ckanext/grouphierarchy/templates/group/read_page_primary_hierarchy.html
@@ -7,6 +7,12 @@
   <li class="active">{% link_for c.group_dict.display_name|truncate(35), controller='group', action='read', id=c.group_dict.name %}</li>
 {% endblock %}
 
+{% block content_action %}
+{% if h.check_access('group_update', {'id': c.group_dict.id}) %}
+{% link_for _('Manage'), controller='group', action='edit', id=c.group_dict.name, class_='btn btn-default btn-right', style='float:right', icon='wrench' %}
+{% endif %}
+{% endblock %}
+
 {% block pre_primary %}
   {% if group.groups|length > 0 %}
     <div class="container single-column group-org-header" xmlns="http://www.w3.org/1999/html">

--- a/ckanext/grouphierarchy/templates/group/snippets/group_parent.html
+++ b/ckanext/grouphierarchy/templates/group/snippets/group_parent.html
@@ -1,12 +1,6 @@
 {% block primary %}
   <article class="module">
     <div class="module-content">
-      {% block page_primary_action %}
-        {% if h.check_access('group_create') %}
-          {% link_for _('Add Thematic Area'), controller='group', action='new', class_='btn btn-primary', icon='plus-sign-alt' %}
-        {% endif %}
-      {% endblock %}
-
       <div class="dataset-detail-org-logo">
         <div class="image">
           <a href="{{ group_url }}">


### PR DESCRIPTION
This adds a manage button to both parent and child topics. 

For child topics it looks like this:

![image](https://user-images.githubusercontent.com/8862002/69974031-c832cd80-1524-11ea-802c-0aeedb2ba4ee.png)

For parent topics it looks like this:

![image](https://user-images.githubusercontent.com/8862002/69974056-d254cc00-1524-11ea-9688-3b220667dfce.png)

I remove the "Add Thematic Area" button from parent topics because it was looking a bit off and we already have it on the topics index page which makes more sense. 

Complementary to: https://github.com/NextGeoss/ckanext-nextgeoss/pull/117